### PR TITLE
ci: migrate e2e tests from previous WPGraphQL IDE Implementation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,14 @@ const { doAction } = wp.hooks;
  * @returns {JSX.Element} The application component.
  */
 export function App() {
-    const [drawerOpen, setDrawerOpen] = useState(false);
+	const params = new URLSearchParams(window.location.search);
+	let defaultOpen = params.has('wpgql_query');
+    const [drawerOpen, setDrawerOpen] = useState( defaultOpen );
+
+	const closeDrawer = () => {
+		params.delete( 'wpgraphql-ide' );
+		setDrawerOpen(false);
+	}
 
     useEffect(() => {
         /**

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -20,8 +20,14 @@ const fetcher = async ( graphQLParams ) => {
 };
 
 export function Editor( { setDrawerOpen } ) {
+
+	const params = new URLSearchParams(window.location.search);
+	let defaultQuery = params.get('wpgql_query');
+
 	return (
-		<GraphiQL fetcher={ fetcher }>
+		<GraphiQL
+			query={defaultQuery}
+			fetcher={ fetcher }>
 			<GraphiQL.Logo>
 				<button
 					className="button EditorDrawerCloseButton"

--- a/tests/e2e/specs/drawer.spec.js
+++ b/tests/e2e/specs/drawer.spec.js
@@ -1,9 +1,14 @@
 import {
-  loginToWordPressAdmin,
-  typeQuery
+	loginToWordPressAdmin,
+	openDrawer,
+	pasteVariables,
+	typeQuery,
+	typeVariables,
+	visitAdminFacingPage,
+	visitPublicFacingPage
 } from '../utils.js';
 
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { test, expect, describe } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const selectors = {
   graphiqlContainer: '.graphiql-container',
@@ -42,6 +47,123 @@ test('should execute a GraphQL query successfully', async ({ page }) => {
   const expectedResponseText = `"posts"`;
   const response = await page.locator(selectors.graphiqlResponse);
 
+  // The valid query executes without errors
+  await expect(response).not.toContainText('errors' );
 
+  // The query returns a payload containing the "posts" payload
   await expect(response).toContainText(expectedResponseText);
+
+});
+
+test( 'should show errors for an invalid query', async ({ page }) => {
+  await page.click(selectors.editorDrawerButton);
+  await expect(page.locator(selectors.graphiqlContainer)).toBeVisible();
+
+  // Type and execute an invalid GraphQL query
+  const query = '{invalidQuery}';
+  await typeQuery(page, query);
+  await page.click(selectors.executeQueryButton);
+  await page.waitForSelector('.graphiql-spinner', { state: 'hidden' }); // Wait for query execution
+
+  // Check for expected response
+  // The invalid query returns an error
+  const response = await page.locator(selectors.graphiqlResponse);
+  await expect(response).toContainText('errors');
+})
+
+
+
+test('drawer opens on an admin page', async ({ page }) => {
+  await visitAdminFacingPage(page);
+  await expect(page.locator('.graphiql-container')).toBeHidden();
+  await openDrawer(page);
+  await expect(page.locator('.graphiql-container')).toBeVisible();
+});
+
+test('drawer opens on a public page', async ({ page }) => {
+  await visitPublicFacingPage(page);
+  const overlay = await page.$('[vaul-overlay]');
+  if (overlay) {
+    await overlay.click();
+  }
+  await expect(page.locator('.graphiql-container')).toBeHidden();
+  await openDrawer(page);
+  const isVisible = await page.locator('.graphiql-container').isVisible();
+  if (!isVisible) {
+    await openDrawer(page);
+  }
+  await expect(page.locator('.graphiql-container')).toBeVisible();
+});
+
+test('loads with the documentation explorer closed', async ({ page }) => {
+  await visitAdminFacingPage(page);
+  await expect(page.locator('.graphiql-container')).toBeHidden();
+  await openDrawer(page);
+  await expect(page.locator('.graphiql-container')).toBeVisible();
+  await expect(page.locator('.graphiql-doc-explorer')).toBeHidden();
+});
+
+test('documentation explorer can be toggled open and closed', async ({ page }) => {
+  await visitAdminFacingPage(page);
+  await expect(page.locator('.graphiql-container')).toBeHidden();
+  await openDrawer(page);
+  await expect(page.locator('.graphiql-container')).toBeVisible();
+  await page.click('[aria-label="Show Documentation Explorer"]');
+  await expect(page.locator('.graphiql-doc-explorer')).toBeVisible();
+  await page.click('[aria-label="Hide Documentation Explorer"]');
+  await expect(page.locator('.graphiql-doc-explorer')).toBeHidden();
+});
+
+test('executes query on public facing page', async ({ page }) => {
+  await visitPublicFacingPage(page);
+  await openDrawer(page);
+  await typeQuery(page, `{posts{nodes{id}}}`);
+  await typeVariables(page, { first: 10 } );
+  await page.click(selectors.executeQueryButton);
+  await page.waitForSelector('.graphiql-spinner', { state: 'hidden' }); // Wait for query execution
+  const response = await page.locator(selectors.graphiqlResponse);
+  await expect(response).toContainText('posts');
+  await expect(response).toContainText('nodes');
+});
+
+
+
+test.skip('expect error if invalid json is submitted for variables', async ({ page }) => {
+
+});
+
+
+text.skip('expect error if invalid query is submitted', async ({ page }) => { });
+
+describe('query params', () => {
+
+	test.skip('loads with fetcher in authenticated state if query param ?wpgql_is_authenticated=true', async ({ page }) => {});
+
+	test.skip('loads with history pane open if ?wpgql_active_plugin=history', async ({ page }) => {});
+	test.skip('loads with docs explorer pane open if ?wpgql_active_plugin=docs', async ({ page }) => {});
+	test.skip('loads with no visible plugin pane open if ?wpgql_active_plugin is not set or does not have a valid plugin name set', async ({ page }) => {});
+
+	test.skip('loads with variables pane populated if ?wpgql_variables is not set or does not have a valid plugin name set', async ({ page }) => {});
+
+
+	test.skip('loads with drawer open if ?wpgql_query exists as a query param', async ({ page }) => {});
+	test.skip('query editor is populated with the query passed in from the ?wpgql_query query param', async ({ page }) => {});
+	test.skip('query editor is populated with the query passed in from the ?wpgql_query query param', async ({ page }) => {});
+
+	test.skip('loads with drawer open if ?wpgql_query_hash exists as a query param', async ({ page }) => {});
+	test.skip('query editor is populated with the (unhashed) query passed in from the ?wpgql_query_hash query param', async ({ page }) => {});
+
+
+	// This tests that the wpgraphql-ide query parameter will load graphiql in an opened state
+	// It also tests that the query parameter will populate the query input
+	// test.skip( 'graphiql loads with ?wpgql_query populated from query parameter', async ({ page }) => {
+	// 	const query = 'query TestQuery{posts{nodes{databaseId}}}';
+	// 	const url = `http://localhost:8888/wp-admin?wpgraphql-ide=open&query=${query}`;
+	// 	await page.goto(url, { waitUntil: 'networkidle' });
+	// 	await expect(page.locator(selectors.graphiqlContainer)).toBeVisible();
+	// 	await page.waitForSelector(selectors.queryInput);
+	// 	const queryInput = await page.locator(selectors.queryInput);
+	// 	await expect(queryInput).toContainText('TestQuery');
+	// });
+
 });

--- a/tests/e2e/specs/drawer.spec.js
+++ b/tests/e2e/specs/drawer.spec.js
@@ -133,7 +133,7 @@ test.skip('expect error if invalid json is submitted for variables', async ({ pa
 });
 
 
-text.skip('expect error if invalid query is submitted', async ({ page }) => { });
+test.skip('expect error if invalid query is submitted', async ({ page }) => { });
 
 describe('query params', () => {
 

--- a/tests/e2e/specs/drawer.spec.js
+++ b/tests/e2e/specs/drawer.spec.js
@@ -8,7 +8,7 @@ import {
 	visitPublicFacingPage
 } from '../utils.js';
 
-const { test, expect, describe } = require( '@wordpress/e2e-test-utils-playwright' );
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const selectors = {
   graphiqlContainer: '.graphiql-container',
@@ -135,7 +135,7 @@ test.skip('expect error if invalid json is submitted for variables', async ({ pa
 
 test.skip('expect error if invalid query is submitted', async ({ page }) => { });
 
-describe('query params', () => {
+test.describe('query params', () => {
 
 	test.skip('loads with fetcher in authenticated state if query param ?wpgql_is_authenticated=true', async ({ page }) => {});
 
@@ -147,7 +147,6 @@ describe('query params', () => {
 
 
 	test.skip('loads with drawer open if ?wpgql_query exists as a query param', async ({ page }) => {});
-	test.skip('query editor is populated with the query passed in from the ?wpgql_query query param', async ({ page }) => {});
 	test.skip('query editor is populated with the query passed in from the ?wpgql_query query param', async ({ page }) => {});
 
 	test.skip('loads with drawer open if ?wpgql_query_hash exists as a query param', async ({ page }) => {});


### PR DESCRIPTION
- migrate tests from existing WPGraphQL IDE. see: https://github.com/wp-graphql/wp-graphql/blob/develop/tests/e2e/graphiql.spec.js
- scaffold some new tests for supporting various query params