### PR TITLE
Dedicated IDE screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from '@wordpress/element';
+import { doAction } from '@wordpress/hooks';
+
 import { EditorDrawer } from './components/EditorDrawer';
 import { Editor } from './components/Editor';
-
-// Assuming wp.hooks is globally available through WordPress's script enqueueing mechanism.
-const { doAction } = wp.hooks;
 
 /**
  * The main application component.

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -50,6 +50,16 @@ function user_lacks_capability(): bool {
     return ! current_user_can( $capability_required );
 }
 
+function is_dedicated_ide_page(): bool {
+    $screen = get_current_screen();
+
+    if ( 'toplevel_page_graphiql-ide' === $screen->id || 'toplevel_page_graphql-ide' === $screen->id ) {
+        return true;
+    }
+
+    return false;
+}
+
 /**
  * Registers a custom menu item in the WordPress Admin Bar.
  *
@@ -60,6 +70,10 @@ function user_lacks_capability(): bool {
  * @return void
  */
 function register_wpadminbar_menu(): void {
+    if ( is_dedicated_ide_page() ) {
+        return;
+    }
+
     if ( user_lacks_capability() ) {
         return;
     }
@@ -82,6 +96,10 @@ add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_wpadminbar_menu', 999 
  * @return void
  */
 function enqueue_graphql_ide_menu_icon_css(): void {
+    if ( is_dedicated_ide_page() ) {
+        return;
+    }
+
     if ( user_lacks_capability() ) {
         return;
     }
@@ -110,9 +128,14 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_graphql_ide_menu_ic
  * @return void
  */
 function enqueue_react_app_with_styles(): void {
+    if ( is_dedicated_ide_page() ) {
+        return;
+    }
+
     if ( ! class_exists( '\WPGraphQL\Router' ) ) {
         return;
     }
+
     if ( user_lacks_capability() ) {
         return;
     }

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -67,8 +67,8 @@ function is_dedicated_ide_page(): bool {
     }
 
     $dedicated_ide_screens = [
-        'toplevel_page_graphiql-ide',
-        'graphql_page_graphql-ide',
+        'toplevel_page_graphiql-ide', // old - GraphiQL IDE
+        'graphql_page_graphql-ide',   // new - GraphQL IDE
     ];
 
     return in_array( $screen->id, $dedicated_ide_screens, true );


### PR DESCRIPTION
This PR introduces a new submenu page for the GraphQL IDE, providing direct access to a dedicated GraphQL environment. The addition aims to streamline the development and testing process for our team and users with sufficient permissions and provide a non-drawer based way to interact with the editor that is similar the current IDE.

