### PR TITLE
ci: migrate unit tests

### DIFF
--- a/tests/unit/specs/GraphiQLToolbar.test.js
+++ b/tests/unit/specs/GraphiQLToolbar.test.js
@@ -1,0 +1,17 @@
+/**
+ * @todo should this test live near the component it is testing?
+ *
+ * related: https://github.com/wp-graphql/wpgraphql-ide/issues/31
+ */
+describe('GraphiQL Toolbar', () => {
+
+	test('it should render', () => {})
+	test.skip('it should render with prettify button', () => {})
+
+	test.skip('filter to add button as the first toolbar button', () => {})
+	test.skip('filter to add button as the last toolbar button', () => {})
+	test.skip('filter to add button after the prettify button', () => {})
+	test.skip('filter to remove prettify button', () => {})
+	test.skip('filter remove all buttons except a custom button', () => {})
+
+})

--- a/tests/unit/specs/Help.test.js
+++ b/tests/unit/specs/Help.test.js
@@ -1,0 +1,11 @@
+/**
+ * @todo should this test live near the component it is testing?
+ */
+describe('GraphiQL Help Screen', () => {
+
+	test('it should render', () => {})
+	test.skip( 'absolute links should have target="_blank"', () => {})
+	test.skip( 'each card should have a title', () => {})
+	test.skip( 'each card should have an action', () => {})
+
+})


### PR DESCRIPTION
This migrates unit tests from the GraphiQL codebase in core WPGraphQL.

These tests will need to be implemented as the features are worked on, but this brings us up to par with tests that existed in the previous codebase.

closes #16 