### PR TITLE
feat: query composer (explorer) as a "built-in" GraphiQL plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"packages": {
 		"": {
 			"dependencies": {
+				"@graphiql/plugin-explorer": "^1.0.3",
 				"@wordpress/components": "^27.0.0",
 				"@wordpress/data": "^9.22.0",
 				"@wordpress/element": "^5.23.0",
@@ -2342,6 +2343,30 @@
 		"node_modules/@floating-ui/utils": {
 			"version": "0.2.1",
 			"license": "MIT"
+		},
+		"node_modules/@graphiql/plugin-explorer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@graphiql/plugin-explorer/-/plugin-explorer-1.0.3.tgz",
+			"integrity": "sha512-dKgdNXut/CaxfU8lcFDi1Jb/5f7NnCHa62E7xlNUNYRzieZ7+Bka0rvspgxzXPYevviigzmrtPGtHd5SeaZ57g==",
+			"dependencies": {
+				"graphiql-explorer": "^0.9.0"
+			},
+			"peerDependencies": {
+				"@graphiql/react": "^0.20.3",
+				"graphql": "^15.5.0 || ^16.0.0",
+				"react": "^16.8.0 || ^17 || ^18",
+				"react-dom": "^16.8.0 || ^17 || ^18"
+			}
+		},
+		"node_modules/@graphiql/plugin-explorer/node_modules/graphiql-explorer": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.9.0.tgz",
+			"integrity": "sha512-fZC/wsuatqiQDO2otchxriFO0LaWIo/ovF/CQJ1yOudmY0P7pzDiP+l9CEHUiWbizk3e99x6DQG4XG1VxA+d6A==",
+			"peerDependencies": {
+				"graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
+				"react": "^15.6.0 || ^16.0.0",
+				"react-dom": "^15.6.0 || ^16.0.0"
+			}
 		},
 		"node_modules/@graphiql/react": {
 			"version": "0.20.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"sort-package-json": "^2.7.0"
 	},
 	"dependencies": {
+		"@graphiql/plugin-explorer": "^1.0.3",
 		"@wordpress/components": "^27.0.0",
 		"@wordpress/data": "^9.22.0",
 		"@wordpress/element": "^5.23.0",

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -8,6 +8,8 @@ import { PrettifyButton } from './toolbarButtons/PrettifyButton';
 import { CopyQueryButton } from './toolbarButtons/CopyQueryButton';
 import { MergeFragmentsButton } from './toolbarButtons/MergeFragmentsButton';
 import { ShareDocumentButton } from './toolbarButtons/ShareDocumentButton';
+import { explorerPlugin } from "@graphiql/plugin-explorer";
+const explorer = explorerPlugin();
 
 import 'graphiql/graphiql.min.css';
 
@@ -49,6 +51,11 @@ export function Editor() {
 	);
 
 	const { setDrawerOpen, setQuery } = useDispatch( 'wpgraphql-ide' );
+
+	let activePlugins = plugins.length > 0 ? plugins : [];
+
+	// Push the explorer plugin to the activePlugins array
+	activePlugins.push( explorer );
 
 	return (
 		<GraphiQL


### PR DESCRIPTION
This implements the `@graphiql/plugin-explorer` as a "built-in" GraphiQL plugin.

Unfortunately, I don't think this will work as-is. There are some funky issues with it. 

- The close button doesn't interact with the state and doesn't close the panel. 
- The panel is not scrollable
- The input throws errors

https://github.com/wp-graphql/wpgraphql-ide/assets/1260765/b2788d94-aa42-4d26-b7b3-65db58a0c62e

Some of these issues _might_ be able to be resolved via CSS adjustments, but I think ultimately we'll need to pull the source code of the plugin and include it in our codebase instead of relying on it as a 3rd party plugin. 

If we take a look at the plugin, we can see that it's a thin wrapper over the GraphQL Explorer that was built for the _old_ GraphiQL IDE that did not have a plugin system, and as such it's not making use of current things like the activity panel state, etc.

Additionally, as we we work on things like implementing Custom Scalars, image uploads, etc, the composer as-is won't know how to support those scalars, so we will _need_ to control the source code at a more granular level anyway.

---- 

related #5 