### PR TITLE
fix: hide generic admin notices on IDE page and properly display graphql admin notices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export const hooks = createHooks();
 window.WPGraphQLIDE = {
 	hooks,
 	store,
-	GraphQL
+	GraphQL,
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export const hooks = createHooks();
 window.WPGraphQLIDE = {
 	hooks,
 	store,
-	GraphQL,
+	GraphQL
 };
 
 /**

--- a/styles/wpgraphql-ide.css
+++ b/styles/wpgraphql-ide.css
@@ -4,6 +4,11 @@
  * Based on https://raw.githubusercontent.com/emilkowalski/vaul/main/src/style.css
  */
 
+
+.graphql_page_graphql-ide #wpbody-content > *:not(#wpgraphql-ide-root):not(.wpgraphql-admin-notice) {
+	display: none;
+}
+
 [vaul-drawer] {
   touch-action: none;
   transform: translate3d(0, 100%, 0);

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -360,3 +360,21 @@ add_action( 'graphql_admin_notices_render_notice', function( string $notice_slug
 	';
 
 }, 10, 4 );
+
+/**
+ * Filter to allow graphql admin notices to be displayed on the dedicated IDE page.
+ *
+ * @param bool $is_plugin_scoped_page True if the current page is within scope of the plugin's pages.
+ * @param string $current_page_id The ID of the current admin page.
+ * @param array<string> $allowed_pages The list of allowed pages.
+ */
+add_filter( 'graphql_admin_notices_is_plugin_scoped_page', function( bool $is_plugin_scoped_page, string $current_page_id, array $allowed_pages ) {
+
+	// If the current page is the dedicated IDE page, we want to allow notices to be displayed.
+	if ( 'graphql_page_graphql-ide' === $current_page_id ) {
+		return true;
+	}
+
+	return $is_plugin_scoped_page;
+
+}, 10, 3 );

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -377,7 +377,7 @@ add_action(
  * @param array<string> $allowed_pages The list of allowed pages.
  */
 add_filter(
-	'graphql_admin_notices_is_plugin_scoped_page',
+	'graphql_admin_notices_is_allowed_admin_page',
 	static function ( bool $is_plugin_scoped_page, string $current_page_id, array $allowed_pages ) {
 
 		// If the current page is the dedicated IDE page, we want to allow notices to be displayed.

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -318,9 +318,11 @@ function get_app_context(): array {
  *
  * @param array $notices The array of notices to render
  */
-add_action( 'graphql_admin_notices_render_notices', function( array $notices ) {
+add_action(
+	'graphql_admin_notices_render_notices',
+	static function ( array $notices ) {
 
-	echo '
+		echo '
 		<style>
             body.graphql_page_graphql-ide #wpbody .wpgraphql-admin-notice {
                 display: block;
@@ -331,15 +333,17 @@ add_action( 'graphql_admin_notices_render_notices', function( array $notices ) {
                 min-width: 40%;
             }
             body.graphql_page_graphql-ide #wpbody .graphiql-container {
-                padding-top: ' . count( $notices ) * 45 .'px;
+                padding-top: ' . count( $notices ) * 45 . 'px;
             }
             body.graphql_page_graphql-ide #wpgraphql-ide-root {
-                height: calc(100vh - var(--wp-admin--admin-bar--height) - '. count( $notices ) * 45 . 'px);
+                height: calc(100vh - var(--wp-admin--admin-bar--height) - ' . count( $notices ) * 45 . 'px);
             }
         </style>
 	';
-
-}, 10, 1 );
+	},
+	10,
+	1 
+);
 
 /**
  * Add styles to apply top margin to notices added via register_graphql_admin_notice
@@ -349,17 +353,21 @@ add_action( 'graphql_admin_notices_render_notices', function( array $notices ) {
  * @param bool $is_dismissable Whether the notice is dismissable
  * @param int $count The count of notices
  */
-add_action( 'graphql_admin_notices_render_notice', function( string $notice_slug, array $notice, bool $is_dismissable, int $count ) {
+add_action(
+	'graphql_admin_notices_render_notice',
+	static function ( string $notice_slug, array $notice, bool $is_dismissable, int $count ) {
 
-	echo '
+		echo '
 	<style>
-        body.graphql_page_graphql-ide #wpbody #wpgraphql-admin-notice-'. esc_attr( $notice_slug ) .' {
+        body.graphql_page_graphql-ide #wpbody #wpgraphql-admin-notice-' . esc_attr( $notice_slug ) . ' {
             top: ' . esc_attr( ( $count * 45 ) . 'px' ) . '
         }
     </style>
 	';
-
-}, 10, 4 );
+	},
+	10,
+	4 
+);
 
 /**
  * Filter to allow graphql admin notices to be displayed on the dedicated IDE page.
@@ -368,13 +376,17 @@ add_action( 'graphql_admin_notices_render_notice', function( string $notice_slug
  * @param string $current_page_id The ID of the current admin page.
  * @param array<string> $allowed_pages The list of allowed pages.
  */
-add_filter( 'graphql_admin_notices_is_plugin_scoped_page', function( bool $is_plugin_scoped_page, string $current_page_id, array $allowed_pages ) {
+add_filter(
+	'graphql_admin_notices_is_plugin_scoped_page',
+	static function ( bool $is_plugin_scoped_page, string $current_page_id, array $allowed_pages ) {
 
-	// If the current page is the dedicated IDE page, we want to allow notices to be displayed.
-	if ( 'graphql_page_graphql-ide' === $current_page_id ) {
-		return true;
-	}
+		// If the current page is the dedicated IDE page, we want to allow notices to be displayed.
+		if ( 'graphql_page_graphql-ide' === $current_page_id ) {
+			return true;
+		}
 
-	return $is_plugin_scoped_page;
-
-}, 10, 3 );
+		return $is_plugin_scoped_page;
+	},
+	10,
+	3 
+);

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -134,7 +134,7 @@ function register_wpadminbar_menus(): void {
 				'href'  => '#',
 			]
 		);
-	}   
+	}
 }
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_wpadminbar_menus', 999 );
 
@@ -311,3 +311,52 @@ function get_app_context(): array {
 		]
 	);
 }
+
+/**
+ * Add styles to hide generic admin notices on the graphiql-ide page
+ * and play nice with notices added via register_graphql_admin_notice
+ *
+ * @param array $notices The array of notices to render
+ */
+add_action( 'graphql_admin_notices_render_notices', function( array $notices ) {
+
+	echo '
+		<style>
+            body.graphql_page_graphql-ide #wpbody .wpgraphql-admin-notice {
+                display: block;
+                position: absolute;
+                top: 0;
+                right: 0;
+                z-index: 1;
+                min-width: 40%;
+            }
+            body.graphql_page_graphql-ide #wpbody .graphiql-container {
+                padding-top: ' . count( $notices ) * 45 .'px;
+            }
+            body.graphql_page_graphql-ide #wpgraphql-ide-root {
+                height: calc(100vh - var(--wp-admin--admin-bar--height) - '. count( $notices ) * 45 . 'px);
+            }
+        </style>
+	';
+
+}, 10, 1 );
+
+/**
+ * Add styles to apply top margin to notices added via register_graphql_admin_notice
+ *
+ * @param string $notice_slug The slug of the notice
+ * @param array $notice The notice data
+ * @param bool $is_dismissable Whether the notice is dismissable
+ * @param int $count The count of notices
+ */
+add_action( 'graphql_admin_notices_render_notice', function( string $notice_slug, array $notice, bool $is_dismissable, int $count ) {
+
+	echo '
+	<style>
+        body.graphql_page_graphql-ide #wpbody #wpgraphql-admin-notice-'. esc_attr( $notice_slug ) .' {
+            top: ' . esc_attr( ( $count * 45 ) . 'px' ) . '
+        }
+    </style>
+	';
+
+}, 10, 4 );


### PR DESCRIPTION
This makes use of the new actions and filters introduced in https://github.com/wp-graphql/wp-graphql/pull/3091 to allow for admin notices registered by `register_graphql_admin_notice` to be displayed properly. It also addresses styles related to generic admin notices being displayed on the graphql-ide page. 

### BEFORE

Here we can see that no graphql admin notices are displayed, but general admin notices are. This is a departure from the "legacy" IDE which hid general admin notices, but displayed graphql admin notices. 

Admin notices would push down the IDE and cause funky display issues.

![CleanShot 2024-04-03 at 12 24 55](https://github.com/wp-graphql/wpgraphql-ide/assets/1260765/55a4cb64-7155-46cb-9844-5626f8199c76)


### AFTER

Here we can see the general admin notices are not displayed, but the specific graphql admin notices are. 

The admin notices stack and styling compensates so that the IDE can still be used without weird scroll issues.

![CleanShot 2024-04-03 at 12 21 09](https://github.com/wp-graphql/wpgraphql-ide/assets/1260765/45dfe0b9-7eb9-4d1f-8d3b-d48026a8eb59)

----

related: https://github.com/wp-graphql/wp-graphql/pull/3091
related: https://github.com/wp-graphql/wp-graphql/issues/3090
related: https://github.com/wp-graphql/wpgraphql-ide/issues/89