### PR TITLE
fix: update z-index of the CodeMirror-info tooltip to show above the drawer

### DIFF
--- a/.changeset/itchy-queens-confess.md
+++ b/.changeset/itchy-queens-confess.md
@@ -1,0 +1,5 @@
+---
+"wpgraphql-ide": patch
+---
+
+fix: update z-index of the CodeMirror-info tooltip to show above the drawer

--- a/styles/wpgraphql-ide.css
+++ b/styles/wpgraphql-ide.css
@@ -239,3 +239,6 @@ body.graphql_page_graphql-ide .AppRoot {
 .graphiql-container .graphiql-editor-tools>button.active {
 	background-color: hsla(var(--color-neutral), var(--alpha-background-medium));
 }
+
+/** Fix for the CodeMirror info tooltip */
+.CodeMirror-info { z-index: 999999; }


### PR DESCRIPTION
This fixes a bug where the Tooltip for fields in the GraphQL Document was not visible when the IDE was opened in a drawer. 

### Before

The tooltip does not show. You can inspect the DOM and see the markup is present, but it's not visible.

![CleanShot 2024-04-19 at 14 05 38](https://github.com/wp-graphql/wpgraphql-ide/assets/1260765/641c44a4-aa3e-41c4-9ae8-3c3d5fe11751)


### After

Now the tooltip shows 👏🏻 

![CleanShot 2024-04-19 at 14 05 02](https://github.com/wp-graphql/wpgraphql-ide/assets/1260765/4c0ab76e-f872-4d0f-98e4-5011a9760a3a)
