### PR TITLE
Defer script to assist with lowering the drawer delay on some pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
 	"name": "wpgraphql-ide",
+	"version": "1.1.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "wpgraphql-ide",
+			"version": "1.1.8",
 			"dependencies": {
 				"@changesets/cli": "^2.27.1",
 				"@graphiql/plugin-explorer": "^1.0.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 /* global WPGRAPHQL_IDE_DATA */
-import { createRoot, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { doAction } from '@wordpress/hooks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { parse, print } from 'graphql';
@@ -8,7 +8,7 @@ import LZString from 'lz-string';
 import { EditorDrawer } from './components/EditorDrawer';
 import { Editor } from './components/Editor';
 
-const { isDedicatedIdePage } = window.WPGRAPHQL_IDE_DATA;
+const { isDedicatedIdePage, context: { drawerButtonLabel } } = window.WPGRAPHQL_IDE_DATA;
 
 const url = new URL( window.location.href );
 const params = url.searchParams;
@@ -129,7 +129,7 @@ export function RenderApp() {
 
 	return (
 		<div className="AppRoot">
-			<EditorDrawer>
+			<EditorDrawer buttonLabel={drawerButtonLabel}>
 				<Editor />
 			</EditorDrawer>
 		</div>

--- a/src/components/EditorDrawer.jsx
+++ b/src/components/EditorDrawer.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Drawer as VaulDrawer } from 'vaul';
 import { useDispatch, useSelect } from '@wordpress/data';
 
-export function EditorDrawer( { children } ) {
-	const buttonLabel = '🚀';
-
+export function EditorDrawer( { children, buttonLabel } ) {
 	const isDrawerOpen = useSelect( ( select ) => {
 		return select( 'wpgraphql-ide' ).isDrawerOpen();
 	} );

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,57 @@
-// WordPress dependencies for hooks, data handling, and component rendering.
+// Import WordPress dependencies for hooks, data handling, and component rendering.
 import { createHooks } from '@wordpress/hooks';
 import { register } from '@wordpress/data';
-import { createRoot } from '@wordpress/element';
+import { render, createRoot } from '@wordpress/element';
 import * as GraphQL from "graphql/index.js";
 
-// Local imports including the store configuration and the main App component.
+// Import local store configuration and the main App component.
 import { store } from './store';
 import { App } from './App';
 
-// Register the store with wp.data to make it available throughout the plugin.
-register( store );
+/**
+ * Registers the store with WordPress data module to make it globally accessible.
+ */
+register(store);
 
-// Create a central event hook system for the WPGraphQL IDE.
+/**
+ * Creates a central event hook system for the WPGraphQL IDE, facilitating the extension
+ * of functionality through external scripts and internal hooks.
+ */
 export const hooks = createHooks();
 
-// Expose a global variable for the IDE, facilitating extension through external scripts.
+/**
+ * Exposes a global IDE variable, making it accessible for extensions and external scripts.
+ */
 window.WPGraphQLIDE = {
-	hooks,
-	store,
-	GraphQL
+    hooks,
+    store,
+    GraphQL
 };
 
 /**
- * Initialize and render the application once the DOM is fully loaded.
- * This ensures that the application mounts when all page elements are available.
+ * Function to abstract the differences in rendering methods between different versions of React.
+ * Uses `createRoot` if available, falling back to `render` if not, to accommodate different React versions.
+ *
+ * @param {HTMLElement} root - The DOM element where the React component will be mounted.
+ * @param {ReactElement} component - The React component to render.
  */
-document.addEventListener( 'DOMContentLoaded', () => {
-	const appMountPoint = document.getElementById( 'wpgraphql-ide-root' );
-	if ( appMountPoint ) {
-		createRoot( appMountPoint ).render( <App /> );
-	} else {
-		console.error(
-			'WPGraphQL IDE mount point not found. Please ensure an element with ID "wpgraphql-ide-root" exists.'
-		);
-	}
-} );
+function compatibleRender(root, component) {
+    if (typeof createRoot !== 'undefined') {
+        createRoot(root).render(component);
+    } else {
+        render(component, root);
+    }
+}
+
+/**
+ * Immediately attempt to render the React application to the designated mount point.
+ * This assumes that the script is loaded with 'defer', ensuring the DOM is parsed beforehand.
+ */
+const appMountPoint = document.getElementById('wpgraphql-ide-root');
+if (appMountPoint) {
+    compatibleRender(appMountPoint, <App />);
+} else {
+    console.error(
+        'WPGraphQL IDE mount point not found. Please ensure an element with ID "wpgraphql-ide-root" exists.'
+    );
+}

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -117,6 +117,8 @@ function register_wpadminbar_menus(): void {
 
 	global $wp_admin_bar;
 
+	$app_context = get_app_context();
+
 	// Link to the new dedicated IDE page.
 	$wp_admin_bar->add_node(
 		[
@@ -131,7 +133,7 @@ function register_wpadminbar_menus(): void {
 		$wp_admin_bar->add_node(
 			[
 				'id'    => 'wpgraphql-ide-button',
-				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '"></div>',
+				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . $app_context['drawerButtonLoadingLabel']. '</div>',
 				'href'  => '#',
 			]
 		);
@@ -305,10 +307,12 @@ function get_app_context(): array {
 	return apply_filters(
 		'wpgraphqlide_context',
 		[
-			'pluginVersion'     => get_plugin_header( 'Version' ),
-			'pluginName'        => get_plugin_header( 'Name' ),
-			'externalFragments' => apply_filters( 'wpgraphqlide_external_fragments', [] ),
-			'avatarUrl'         => $avatar_url,
+			'pluginVersion'            => get_plugin_header( 'Version' ),
+			'pluginName'               => get_plugin_header( 'Name' ),
+			'externalFragments'        => apply_filters( 'wpgraphqlide_external_fragments', [] ),
+			'avatarUrl'                => $avatar_url,
+			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', '🚀' ),
+			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', '⏳' ),
 		]
 	);
 }
@@ -390,4 +394,30 @@ add_filter(
 	},
 	10,
 	3 
+);
+
+/**
+ * Modifies the script tag for specific scripts to add the 'defer' attribute.
+ *
+ * This function checks if the script handle matches 'wpgraphql-ide' and, if so, 
+ * adds the 'defer' attribute to the script tag. This allows the script to be executed 
+ * after the HTML document is parsed but before the DOMContentLoaded event.
+ *
+ * @param string $tag    The HTML `<script>` tag of the enqueued script.
+ * @param string $handle The script's registered handle in WordPress.
+ *
+ * @return string Modified script tag with 'defer' attribute included if handle matches; otherwise, unchanged.
+ */
+add_filter(
+	'script_loader_tag',
+	static function( string $tag, string $handle ) {
+
+		if ( 'wpgraphql-ide' === $handle ) {
+			return str_replace( ' src', ' defer="defer" src', $tag );
+		}
+
+		return $tag;
+	},
+	10,
+	2
 );


### PR DESCRIPTION
Proposed solution for issue #124:

- Removed the check for `DOMContentLoaded` in order to help client side performance with heavier pages.
- Added new PHP filters for updating the drawer label:
  - `wpgraphqlide_drawer_button_label`
  - `wpgraphqlide_drawer_button_loading_label`
