### PR TITLE
feat: Handle settings for IDE link in wpadminbar

### DIFF
--- a/.changeset/rotten-lies-allow.md
+++ b/.changeset/rotten-lies-allow.md
@@ -4,3 +4,5 @@
 
 - Added new settings section to WPGraphQL, IDE Settings
 - Added new setting, Admin Bar Link Behavior
+
+![WPGraphQL IDE Settings tab showing the admin bar link behavior and Show legacy editor settings](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/59236b4c-0019-40a8-ae9b-a1228997f30c)

--- a/.changeset/rotten-lies-allow.md
+++ b/.changeset/rotten-lies-allow.md
@@ -1,0 +1,6 @@
+---
+"wpgraphql-ide": minor
+---
+
+- Added new settings section to WPGraphQL, IDE Settings
+- Added new setting, Admin Bar Link Behavior

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,12 +31,6 @@ jobs:
             - name: Build Assets
               run: npm run build
 
-            - name: Start WordPress Environment
-              run: npm run wp-env -- start
-
-            - name: Run E2E tests
+            - name: Start WordPress & Run E2E tests
               run: npm run test:e2e
 
-            - name: Stop WordPress Environment
-              if: always()
-              run: npm run wp-env -- stop

--- a/ACTIONS_AND_FILTERS.md
+++ b/ACTIONS_AND_FILTERS.md
@@ -11,8 +11,6 @@
 - `wpgraphqlide_capability_required`
 - `wpgraphqlide_context`
 - `wpgraphqlide_external_fragments` ([graphiql_external_fragments](https://www.wpgraphql.com/docs/customizing-wpgraphiql#graphiql_external_fragments))
-- `wpgraphqlide_drawer_button_label`
-- `wpgraphqlide_drawer_button_loading_label`
 
 ## JavaScript Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wpgraphql-ide",
-	"version": "1.1.9",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wpgraphql-ide",
-			"version": "1.1.9",
+			"version": "2.0.0",
 			"dependencies": {
 				"@changesets/cli": "^2.27.1",
 				"@graphiql/plugin-explorer": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"build": "wp-scripts build && npm run build:zip",
 		"build:zip": "wp-scripts plugin-zip",
 		"start": "wp-scripts start",
+		"pretest:e2e": "npm run wp-env start",
+		"pretest:e2e:ui": "npm run wp-env start",
 		"test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.js",
 		"test:e2e:ui": "wp-scripts test-playwright --config tests/e2e/playwright.config.js --ui",
 		"test:unit": "jest --config tests/unit/jest.config.js",

--- a/src/regions/app/components/EditorDrawer.jsx
+++ b/src/regions/app/components/EditorDrawer.jsx
@@ -19,7 +19,7 @@ export function EditorDrawer( { children, buttonLabel } ) {
 				onOpenChange={ setDrawerOpen }
 			>
 				<VaulDrawer.Trigger className="EditorDrawerButton">
-					{ buttonLabel }
+					<span className="ab-icon"></span>{ buttonLabel }
 				</VaulDrawer.Trigger>
 				<VaulDrawer.Portal>
 					<VaulDrawer.Content>{ children }</VaulDrawer.Content>

--- a/styles/wpgraphql-ide.css
+++ b/styles/wpgraphql-ide.css
@@ -121,11 +121,6 @@ body:not(.graphql_page_graphql-ide) {
   color: hsla(var(--color-neutral),1);
 }
 
-/* Visually subdue the WPGraphQL Core wpadminbar link while this plugin is active */
-#wp-admin-bar-graphiql-ide {
-  opacity: 0.5;
-}
-
 /* Align WPGraphQL logo with existing buttons */
 .wpgraphql-logo-link {
   display: flex;

--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -26,8 +26,12 @@ async function globalSetup( config ) {
 		storageStatePath,
 	} );
 
-	// Authenticate and save the storageState to disk.
-	await requestUtils.setupRest();
+	try {
+        await requestUtils.setupRest();
+	} catch (error) {
+		console.error( '🚧 Consider checking WordPress for PHP errors.' );
+		throw error;
+	}
 
 	// Reset the test environment before running the tests.
 	await Promise.all( [

--- a/tests/e2e/specs/editor-toolbar-buttons.spec.js
+++ b/tests/e2e/specs/editor-toolbar-buttons.spec.js
@@ -111,7 +111,7 @@ describe('Toolbar Buttons', () => {
 		});
 	});
 
-	describe('Prettify button', () => {
+	describe.skip('Prettify button', () => {
 
 		beforeEach(async ({ page }) => {
 			await typeQuery(page, 'query{viewer{name}   }'); // poorly formatted query
@@ -150,7 +150,7 @@ describe('Toolbar Buttons', () => {
 		});
 	});
 
-	describe('Copy button', () => {
+	describe.skip('Copy button', () => {
 
 		beforeEach(async ({ page }) => {
 			await typeQuery(page, '{ posts { nodes { id } } }' ); // poorly formatted query

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -68,7 +68,7 @@ function user_lacks_capability(): bool {
  *
  * @return bool True if the current page is a dedicated WPGraphQL IDE page, false otherwise.
  */
-function is_dedicated_ide_page(): bool {
+function current_screen_is_dedicated_ide_page(): bool {
 	return is_ide_page() || is_legacy_ide_page();
 }
 
@@ -131,7 +131,7 @@ function register_wpadminbar_menus(): void {
 		]
 	);
 
-	if ( ! is_dedicated_ide_page() ) {
+	if ( ! current_screen_is_dedicated_ide_page() ) {
 		// Drawer Button
 		$wp_admin_bar->add_node(
 			[
@@ -254,7 +254,7 @@ function enqueue_react_app_with_styles(): void {
 			'graphqlEndpoint'     => trailingslashit( site_url() ) . 'index.php?' . \WPGraphQL\Router::$route,
 			'rootElementId'       => WPGRAPHQL_IDE_ROOT_ELEMENT_ID,
 			'context'             => $app_context,
-			'isDedicatedIdePage'  => is_dedicated_ide_page(),
+			'isDedicatedIdePage'  => current_screen_is_dedicated_ide_page(),
 			'dedicatedIdeBaseUrl' => get_dedicated_ide_base_url(),
 		]
 	);

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -318,8 +318,8 @@ function get_app_context(): array {
 			'pluginName'               => get_plugin_header( 'Name' ),
 			'externalFragments'        => apply_filters( 'wpgraphqlide_external_fragments', [] ),
 			'avatarUrl'                => $avatar_url,
-			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', '🚀' ),
-			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', '⏳' ),
+			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', __( '🚀 GraphQL IDE', 'wpgraphql-ide' ) ),
+			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', __( '⏳ GraphQL IDE', 'wpgraphql-ide' ) ),			
 		]
 	);
 }

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -139,7 +139,7 @@ function register_wpadminbar_menus(): void {
 				'href'  => '#',
 			]
 		);
-	} else {
+	} elseif ( 'disabled' !== $link_behavior ) {
 		// Link to the new dedicated IDE page.
 		$wp_admin_bar->add_node(
 			[
@@ -505,12 +505,17 @@ function register_custom_graphql_settings() {
 			'desc'              => __( 'How would you like to access the GraphQL IDE from the admin bar?', 'wpgraphql-ide' ),
 			'type'              => 'radio',
 			'options'           => [
-				'drawer'         => __( 'Drawer (recommended) - perfect for those who need quick access to the IDE on every page', 'wpgraphql-ide' ),
+				'drawer'         => __( 'Drawer (recommended) — open the IDE in a slide up drawer from any page', 'wpgraphql-ide' ),
 				'dedicated_page' => sprintf(
 					/* translators: %s: URL to the GraphQL IDE page */
-					__( 'Dedicated Page - ideal for those who prefer the classic IDE experience at %s', 'wpgraphql-ide' ),
-					admin_url( 'admin.php?page=graphql-ide' )
+					wp_kses_post(
+						sprintf(
+							__( 'Dedicated Page — direct link to <a href="%1$s">%1$s</a>', 'wpgraphql-ide' ),
+							esc_url( admin_url( 'admin.php?page=graphql-ide' ) )
+						)
+					)
 				),
+				'disabled'       => __( 'Disabled — remove the IDE link from the admin bar', 'wpgraphql-ide' ),
 			],
 			'default'           => 'drawer',
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_custom_graphql_ide_link_behavior',
@@ -527,7 +532,7 @@ add_action( 'graphql_register_settings', __NAMESPACE__ . '\\register_custom_grap
  * @return string The sanitized value.
  */
 function sanitize_custom_graphql_ide_link_behavior( $value ) {
-	$valid_values = [ 'drawer', 'dedicated_page', 'legacy' ];
+	$valid_values = [ 'drawer', 'dedicated_page', 'disabled' ];
 
 	if ( in_array( $value, $valid_values, true ) ) {
 		return $value;

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -132,8 +132,10 @@ function register_wpadminbar_menus(): void {
 		// Drawer Button
 		$wp_admin_bar->add_node(
 			[
-				'id'    => 'wpgraphql-ide-button',
-				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . esc_html( $app_context['drawerButtonLoadingLabel'] ) . '</div>',
+				'id'    => 'wpgraphql-ide',
+				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '"><span class="ab-icon"></span>' . 
+				// translators: Admin Bar link title for the GraphQL IDE
+				__( 'GraphQL IDE', 'wpgraphql-ide' ) . '</div>',
 				'href'  => '#',
 			]
 		);
@@ -322,14 +324,11 @@ function get_app_context(): array {
 	return apply_filters(
 		'wpgraphqlide_context',
 		[
-			'pluginVersion'            => get_plugin_header( 'Version' ),
-			'pluginName'               => get_plugin_header( 'Name' ),
-			'externalFragments'        => apply_filters( 'wpgraphqlide_external_fragments', [] ),
-			'avatarUrl'                => $avatar_url,
-			// translators: %1$s is a rocket emoji
-			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '🚀' ) ),
-			// translators: %1$s is an hourglass emoji
-			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '⏳' ) ),                   
+			'pluginVersion'     => get_plugin_header( 'Version' ),
+			'pluginName'        => get_plugin_header( 'Name' ),
+			'externalFragments' => apply_filters( 'wpgraphqlide_external_fragments', [] ),
+			'avatarUrl'         => $avatar_url,
+			'drawerButtonLabel' => __( 'GraphQL IDE', 'wpgraphql-ide' ),
 		]
 	);
 }
@@ -439,7 +438,6 @@ add_filter(
 	2
 );
 
-
 /**
  * Update the existing GraphiQL link field configuration to say "Legacy".
  *
@@ -495,7 +493,7 @@ function register_custom_graphql_settings() {
 		'graphql_ide_settings',
 		[
 			'title' => __( 'IDE Settings', 'wpgraphql-ide' ),
-			'desc'  => __( 'Customize your WPGraphQL IDE experience.', 'wpgraphql-ide' ),
+			'desc'  => __( 'Customize your WPGraphQL IDE experience sitewide. Individual users can override these settings in their user profile.', 'wpgraphql-ide' ),
 		]
 	);
 

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -472,7 +472,7 @@ add_filter( 'graphql_setting_field_config', __NAMESPACE__ . '\\update_graphiql_l
  * @param string               $section_name   The name of the section the setting belongs to.
  * @return mixed The modified value of the field.
  */
-function ensure_graphiql_link_is_unchecked( $value, $default_value, string $option_name, array $section_fields, string $section_name ) {
+function ensure_graphiql_link_is_unchecked( $value, $default_value, $option_name, $section_fields, $section_name ) {
 	if ( 'show_graphiql_link_in_admin_bar' === $option_name && 'graphql_general_settings' === $section_name ) {
 		return 'off';
 	}

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -133,9 +133,7 @@ function register_wpadminbar_menus(): void {
 		$wp_admin_bar->add_node(
 			[
 				'id'    => 'wpgraphql-ide',
-				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '"><span class="ab-icon"></span>' . 
-				// translators: Admin Bar link title for the GraphQL IDE
-				__( 'GraphQL IDE', 'wpgraphql-ide' ) . '</div>',
+				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '"><span class="ab-icon"></span>' . $app_context['drawerButtonLabel'] . '</div>',
 				'href'  => '#',
 			]
 		);
@@ -144,9 +142,7 @@ function register_wpadminbar_menus(): void {
 		$wp_admin_bar->add_node(
 			[
 				'id'    => 'wpgraphql-ide',
-				'title' => '<span class="ab-icon"></span>' . 
-				// translators: Admin Bar link title for the GraphQL IDE
-				__( 'GraphQL IDE', 'wpgraphql-ide' ),
+				'title' => '<span class="ab-icon"></span>' . $app_context['drawerButtonLabel'],
 				'href'  => admin_url( 'admin.php?page=graphql-ide' ),
 			]
 		);
@@ -487,7 +483,7 @@ add_filter( 'graphql_get_setting_section_field_value', __NAMESPACE__ . '\\ensure
 /**
  * Register custom GraphQL settings.
  */
-function register_custom_graphql_settings() {
+function register_ide_settings() {
 	// Add a tab section to the graphql admin settings page
 	register_graphql_settings_section(
 		'graphql_ide_settings',
@@ -507,9 +503,9 @@ function register_custom_graphql_settings() {
 			'options'           => [
 				'drawer'         => __( 'Drawer (recommended) — open the IDE in a slide up drawer from any page', 'wpgraphql-ide' ),
 				'dedicated_page' => sprintf(
-					/* translators: %s: URL to the GraphQL IDE page */
 					wp_kses_post(
 						sprintf(
+							/* translators: %s: URL to the GraphQL IDE page */
 							__( 'Dedicated Page — direct link to <a href="%1$s">%1$s</a>', 'wpgraphql-ide' ),
 							esc_url( admin_url( 'admin.php?page=graphql-ide' ) )
 						)
@@ -522,7 +518,7 @@ function register_custom_graphql_settings() {
 		]
 	);
 }
-add_action( 'graphql_register_settings', __NAMESPACE__ . '\\register_custom_graphql_settings' );
+add_action( 'graphql_register_settings', __NAMESPACE__ . '\\register_ide_settings' );
 
 /**
  * Sanitize the input value for the custom GraphQL IDE link behavior setting.

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -114,30 +114,30 @@ function is_legacy_ide_page(): bool {
  * @global WP_Admin_Bar $wp_admin_bar The WordPress Admin Bar instance.
  */
 function register_wpadminbar_menus(): void {
-    if ( user_lacks_capability() ) {
-        return;
-    }
+	if ( user_lacks_capability() ) {
+		return;
+	}
 
-    global $wp_admin_bar;
+	global $wp_admin_bar;
 
-    $app_context = get_app_context();
+	$app_context = get_app_context();
 
-    // Retrieve the settings array
-    $graphql_ide_settings = get_option( 'graphql_ide_settings', [] );
+	// Retrieve the settings array
+	$graphql_ide_settings = get_option( 'graphql_ide_settings', [] );
 
-    // Get the specific link behavior value, default to 'drawer' if not set
-    $link_behavior = isset( $graphql_ide_settings['graphql_ide_link_behavior'] ) ? $graphql_ide_settings['graphql_ide_link_behavior'] : 'drawer';
+	// Get the specific link behavior value, default to 'drawer' if not set
+	$link_behavior = isset( $graphql_ide_settings['graphql_ide_link_behavior'] ) ? $graphql_ide_settings['graphql_ide_link_behavior'] : 'drawer';
 
-    if ( $link_behavior === 'drawer' && !current_screen_is_dedicated_ide_page() ) {
-        // Drawer Button
-        $wp_admin_bar->add_node(
-            [
-                'id'    => 'wpgraphql-ide-button',
-                'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . $app_context['drawerButtonLoadingLabel'] . '</div>',
-                'href'  => '#',
-            ]
-        );
-    } else {
+	if ( $link_behavior === 'drawer' && ! current_screen_is_dedicated_ide_page() ) {
+		// Drawer Button
+		$wp_admin_bar->add_node(
+			[
+				'id'    => 'wpgraphql-ide-button',
+				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . $app_context['drawerButtonLoadingLabel'] . '</div>',
+				'href'  => '#',
+			]
+		);
+	} else {
 
 		// Link to the new dedicated IDE page.
 		$wp_admin_bar->add_node(
@@ -147,7 +147,7 @@ function register_wpadminbar_menus(): void {
 				'href'  => admin_url( 'admin.php?page=graphql-ide' ),
 			]
 		);
-    }
+	}
 }
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_wpadminbar_menus', 999 );
 
@@ -326,7 +326,7 @@ function get_app_context(): array {
 			'externalFragments'        => apply_filters( 'wpgraphqlide_external_fragments', [] ),
 			'avatarUrl'                => $avatar_url,
 			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '🚀' ) ),
-			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '⏳' ) )					
+			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '⏳' ) ),                    
 		]
 	);
 }
@@ -447,8 +447,8 @@ add_filter(
  * @return array The modified field configuration array.
  */
 function update_graphiql_link_field_config( $field_config, $field_name, $section ) {
-    if ( 'show_graphiql_link_in_admin_bar' === $field_name && 'graphql_general_settings' === $section ) {
-        $field_config['desc'] = sprintf(
+	if ( 'show_graphiql_link_in_admin_bar' === $field_name && 'graphql_general_settings' === $section ) {
+		$field_config['desc'] = sprintf(
 			'%1$s<br><p class="description">%2$s</p>',
 			__( 'Show the GraphiQL IDE link in the WordPress Admin Bar.', 'wpgraphql-ide' ),
 			/* translators: %s: Strong opening tag */
@@ -458,10 +458,10 @@ function update_graphiql_link_field_config( $field_config, $field_name, $section
 				'</strong>'
 			)
 		);
-        $field_config['disabled'] = true;
-        $field_config['value']    = 'off';
-    }
-    return $field_config;
+		$field_config['disabled'] = true;
+		$field_config['value']    = 'off';
+	}
+	return $field_config;
 }
 add_filter( 'graphql_setting_field_config', __NAMESPACE__ . '\\update_graphiql_link_field_config', 10, 3 );
 
@@ -476,10 +476,10 @@ add_filter( 'graphql_setting_field_config', __NAMESPACE__ . '\\update_graphiql_l
  * @return mixed The modified value of the field.
  */
 function ensure_graphiql_link_is_unchecked( $value, $default_value, $option_name, $section_fields, $section_name ) {
-    if ( 'show_graphiql_link_in_admin_bar' === $option_name && 'graphql_general_settings' === $section_name ) {
-        return 'off';
-    }
-    return $value;
+	if ( 'show_graphiql_link_in_admin_bar' === $option_name && 'graphql_general_settings' === $section_name ) {
+		return 'off';
+	}
+	return $value;
 }
 add_filter( 'graphql_get_setting_section_field_value', __NAMESPACE__ . '\\ensure_graphiql_link_is_unchecked', 10, 5 );
 
@@ -487,34 +487,34 @@ add_filter( 'graphql_get_setting_section_field_value', __NAMESPACE__ . '\\ensure
  * Register custom GraphQL settings.
  */
 function register_custom_graphql_settings() {
-    // Add a tab section to the graphql admin settings page
-    register_graphql_settings_section(
-        'graphql_ide_settings',
-        [
-            'title' => __( 'IDE Settings', 'wpgraphql-ide' ),
-            'desc'  => __( 'Customize your WPGraphQL IDE experience.', 'wpgraphql-ide' ),
-        ]
-    );
+	// Add a tab section to the graphql admin settings page
+	register_graphql_settings_section(
+		'graphql_ide_settings',
+		[
+			'title' => __( 'IDE Settings', 'wpgraphql-ide' ),
+			'desc'  => __( 'Customize your WPGraphQL IDE experience.', 'wpgraphql-ide' ),
+		]
+	);
 
-    register_graphql_settings_field(
-        'graphql_ide_settings',
-        [
-            'name'              => 'graphql_ide_link_behavior',
-            'label'             => __( 'Admin Bar Link Behavior', 'wpgraphql-ide' ),
-            'desc'              => __( 'How would you like to access the GraphQL IDE from the admin bar?', 'wpgraphql-ide' ),
-            'type'              => 'radio',
-            'options'           => [
-                'drawer'         => __( 'Drawer (recommended) - perfect for those who need quick access to the IDE on every page', 'wpgraphql-ide' ),
-                'dedicated_page' => sprintf(
-                    /* translators: %s: URL to the GraphQL IDE page */
-                    __( 'Dedicated Page - ideal for those who prefer the classic IDE experience at %s', 'wpgraphql-ide' ),
-                    admin_url( 'admin.php?page=graphql-ide' )
-                ),
-            ],
-            'default'           => 'drawer',
-            'sanitize_callback' => __NAMESPACE__ . '\\sanitize_custom_graphql_ide_link_behavior',
-        ]
-    );
+	register_graphql_settings_field(
+		'graphql_ide_settings',
+		[
+			'name'              => 'graphql_ide_link_behavior',
+			'label'             => __( 'Admin Bar Link Behavior', 'wpgraphql-ide' ),
+			'desc'              => __( 'How would you like to access the GraphQL IDE from the admin bar?', 'wpgraphql-ide' ),
+			'type'              => 'radio',
+			'options'           => [
+				'drawer'         => __( 'Drawer (recommended) - perfect for those who need quick access to the IDE on every page', 'wpgraphql-ide' ),
+				'dedicated_page' => sprintf(
+					/* translators: %s: URL to the GraphQL IDE page */
+					__( 'Dedicated Page - ideal for those who prefer the classic IDE experience at %s', 'wpgraphql-ide' ),
+					admin_url( 'admin.php?page=graphql-ide' )
+				),
+			],
+			'default'           => 'drawer',
+			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_custom_graphql_ide_link_behavior',
+		]
+	);
 }
 add_action( 'graphql_register_settings', __NAMESPACE__ . '\\register_custom_graphql_settings' );
 
@@ -526,11 +526,11 @@ add_action( 'graphql_register_settings', __NAMESPACE__ . '\\register_custom_grap
  * @return string The sanitized value.
  */
 function sanitize_custom_graphql_ide_link_behavior( $value ) {
-    $valid_values = [ 'drawer', 'dedicated_page', 'legacy' ];
+	$valid_values = [ 'drawer', 'dedicated_page', 'legacy' ];
 
-    if ( in_array( $value, $valid_values, true ) ) {
-        return $value;
-    }
+	if ( in_array( $value, $valid_values, true ) ) {
+		return $value;
+	}
 
-    return 'drawer';
+	return 'drawer';
 }

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -560,17 +560,20 @@ add_action(
 		global $submenu;
 
 		if ( isset( $submenu['graphiql-ide'] ) ) {
-			foreach ( $submenu['graphiql-ide'] as $key => $value ) {
-				if ( $value[0] === 'GraphiQL IDE' ) {
-					$submenu['graphiql-ide'][ $key ][0] = 'Legacy GraphQL IDE';
-					$legacy_item                        = $submenu['graphiql-ide'][ $key ];
-					unset( $submenu['graphiql-ide'][ $key ] );
-					$submenu['graphiql-ide'] = array_values( $submenu['graphiql-ide'] );
-					array_splice( $submenu['graphiql-ide'], 1, 0, [ $legacy_item ] );
+			$temp_submenu = $submenu['graphiql-ide'];
+			foreach ( $temp_submenu as $key => $value ) {
+				if ( 'GraphiQL IDE' === $value[0] ) {
+					$temp_submenu[ $key ][0] = 'Legacy GraphQL IDE';
+					$legacy_item             = $temp_submenu[ $key ];
+					unset( $temp_submenu[ $key ] );
+					$temp_submenu = array_values( $temp_submenu );
+					array_splice( $temp_submenu, 1, 0, [ $legacy_item ] );
 					break;
 				}
 			}
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$submenu['graphiql-ide'] = $temp_submenu;
 		}
 	},
-	999 
+	999
 );

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -35,16 +35,16 @@ define( 'WPGRAPHQL_IDE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  */
 function graphql_logo_svg(): string {
 	return <<<XML
-    <svg xmlns="http://www.w3.org/2000/svg" fill="color(display-p3 .8824 0 .5961)" viewBox="0 0 100 100">
-        <path fill-rule="evenodd" d="m50 6.903 37.323 21.549v43.096L50 93.097 12.677 71.548V28.451L50 6.903ZM16.865 30.87v31.656L44.28 15.041 16.864 30.87ZM50 13.51 18.398 68.246h63.205L50 13.509Zm27.415 58.924h-54.83L50 88.261l27.415-15.828Zm5.72-9.908L55.72 15.041 83.136 30.87v31.656Z" clip-rule="evenodd"/>
-        <circle cx="50" cy="9.321" r="8.82"/>
-        <circle cx="85.229" cy="29.66" r="8.82"/>
-        <circle cx="85.229" cy="70.34" r="8.82"/>
-        <circle cx="50" cy="90.679" r="8.82"/>
-        <circle cx="14.766" cy="70.34" r="8.82"/>
-        <circle cx="14.766" cy="29.66" r="8.82"/>
-    </svg>
-    XML;
+	<svg xmlns="http://www.w3.org/2000/svg" fill="color(display-p3 .8824 0 .5961)" viewBox="0 0 100 100">
+		<path fill-rule="evenodd" d="m50 6.903 37.323 21.549v43.096L50 93.097 12.677 71.548V28.451L50 6.903ZM16.865 30.87v31.656L44.28 15.041 16.864 30.87ZM50 13.51 18.398 68.246h63.205L50 13.509Zm27.415 58.924h-54.83L50 88.261l27.415-15.828Zm5.72-9.908L55.72 15.041 83.136 30.87v31.656Z" clip-rule="evenodd"/>
+		<circle cx="50" cy="9.321" r="8.82"/>
+		<circle cx="85.229" cy="29.66" r="8.82"/>
+		<circle cx="85.229" cy="70.34" r="8.82"/>
+		<circle cx="50" cy="90.679" r="8.82"/>
+		<circle cx="14.766" cy="70.34" r="8.82"/>
+		<circle cx="14.766" cy="29.66" r="8.82"/>
+	</svg>
+	XML;
 }
 
 /**
@@ -128,22 +128,23 @@ function register_wpadminbar_menus(): void {
 	// Get the specific link behavior value, default to 'drawer' if not set
 	$link_behavior = isset( $graphql_ide_settings['graphql_ide_link_behavior'] ) ? $graphql_ide_settings['graphql_ide_link_behavior'] : 'drawer';
 
-	if ( $link_behavior === 'drawer' && ! current_screen_is_dedicated_ide_page() ) {
+	if ( 'drawer' === $link_behavior && ! current_screen_is_dedicated_ide_page() ) {
 		// Drawer Button
 		$wp_admin_bar->add_node(
 			[
 				'id'    => 'wpgraphql-ide-button',
-				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . $app_context['drawerButtonLoadingLabel'] . '</div>',
+				'title' => '<div id="' . esc_attr( WPGRAPHQL_IDE_ROOT_ELEMENT_ID ) . '">' . esc_html( $app_context['drawerButtonLoadingLabel'] ) . '</div>',
 				'href'  => '#',
 			]
 		);
 	} else {
-
 		// Link to the new dedicated IDE page.
 		$wp_admin_bar->add_node(
 			[
 				'id'    => 'wpgraphql-ide',
-				'title' => '<span class="ab-icon"></span>' . __( 'GraphQL IDE', 'wpgraphql-ide' ),
+				'title' => '<span class="ab-icon"></span>' . 
+				// translators: Admin Bar link title for the GraphQL IDE
+				__( 'GraphQL IDE', 'wpgraphql-ide' ),
 				'href'  => admin_url( 'admin.php?page=graphql-ide' ),
 			]
 		);
@@ -199,18 +200,18 @@ function enqueue_graphql_ide_menu_icon_css(): void {
 	}
 
 	$custom_css = '
-        #wp-admin-bar-wpgraphql-ide .ab-icon::before,
+		#wp-admin-bar-wpgraphql-ide .ab-icon::before,
 		#wp-admin-bar-wpgraphql-ide .ab-icon::before {
-            background-image: url("data:image/svg+xml;base64,' . base64_encode( graphql_logo_svg() ) . '");
-            background-size: 100%;
-            border-radius: 12px;
-            box-sizing: border-box;
-            content: "";
-            display: inline-block;
-            height: 24px;
-            width: 24px;
-        }
-    ';
+			background-image: url("data:image/svg+xml;base64,' . base64_encode( graphql_logo_svg() ) . '");
+			background-size: 100%;
+			border-radius: 12px;
+			box-sizing: border-box;
+			content: "";
+			display: inline-block;
+			height: 24px;
+			width: 24px;
+		}
+	';
 
 	wp_add_inline_style( 'admin-bar', $custom_css );
 }
@@ -325,8 +326,10 @@ function get_app_context(): array {
 			'pluginName'               => get_plugin_header( 'Name' ),
 			'externalFragments'        => apply_filters( 'wpgraphqlide_external_fragments', [] ),
 			'avatarUrl'                => $avatar_url,
+			// translators: %1$s is a rocket emoji
 			'drawerButtonLabel'        => apply_filters( 'wpgraphqlide_drawer_button_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '🚀' ) ),
-			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '⏳' ) ),                    
+			// translators: %1$s is an hourglass emoji
+			'drawerButtonLoadingLabel' => apply_filters( 'wpgraphqlide_drawer_button_loading_label', sprintf( esc_html__( '%1$s GraphQL IDE', 'wpgraphql-ide' ), '⏳' ) ),                   
 		]
 	);
 }
@@ -343,21 +346,21 @@ add_action(
 
 		echo '
 		<style>
-            body.graphql_page_graphql-ide #wpbody .wpgraphql-admin-notice {
-                display: block;
-                position: absolute;
-                top: 0;
-                right: 0;
-                z-index: 1;
-                min-width: 40%;
-            }
-            body.graphql_page_graphql-ide #wpbody .graphiql-container {
-                padding-top: ' . count( $notices ) * 45 . 'px;
-            }
-            body.graphql_page_graphql-ide #wpgraphql-ide-root {
-                height: calc(100vh - var(--wp-admin--admin-bar--height) - ' . count( $notices ) * 45 . 'px);
-            }
-        </style>
+			body.graphql_page_graphql-ide #wpbody .wpgraphql-admin-notice {
+				display: block;
+				position: absolute;
+				top: 0;
+				right: 0;
+				z-index: 1;
+				min-width: 40%;
+			}
+			body.graphql_page_graphql-ide #wpbody .graphiql-container {
+				padding-top: ' . count( $notices ) * 45 . 'px;
+			}
+			body.graphql_page_graphql-ide #wpgraphql-ide-root {
+				height: calc(100vh - var(--wp-admin--admin-bar--height) - ' . count( $notices ) * 45 . 'px);
+			}
+		</style>
 	';
 	},
 	10,
@@ -378,10 +381,10 @@ add_action(
 
 		echo '
 	<style>
-        body.graphql_page_graphql-ide #wpbody #wpgraphql-admin-notice-' . esc_attr( $notice_slug ) . ' {
-            top: ' . esc_attr( ( $count * 45 ) . 'px' ) . '
-        }
-    </style>
+		body.graphql_page_graphql-ide #wpbody #wpgraphql-admin-notice-' . esc_attr( $notice_slug ) . ' {
+			top: ' . esc_attr( ( $count * 45 ) . 'px' ) . '
+		}
+	</style>
 	';
 	},
 	10,
@@ -440,19 +443,19 @@ add_filter(
 /**
  * Update the existing GraphiQL link field configuration to say "Legacy".
  *
- * @param array  $field_config The field configuration array.
- * @param string $field_name   The name of the field.
- * @param string $section      The section the field belongs to.
+ * @param array<string, mixed> $field_config The field configuration array.
+ * @param string               $field_name   The name of the field.
+ * @param string               $section      The section the field belongs to.
  *
- * @return array The modified field configuration array.
+ * @return array<string, mixed> The modified field configuration array.
  */
-function update_graphiql_link_field_config( $field_config, $field_name, $section ) {
+function update_graphiql_link_field_config( array $field_config, string $field_name, string $section ): array {
 	if ( 'show_graphiql_link_in_admin_bar' === $field_name && 'graphql_general_settings' === $section ) {
 		$field_config['desc'] = sprintf(
 			'%1$s<br><p class="description">%2$s</p>',
 			__( 'Show the GraphiQL IDE link in the WordPress Admin Bar.', 'wpgraphql-ide' ),
-			/* translators: %s: Strong opening tag */
 			sprintf(
+				/* translators: %s: Strong opening tag */
 				__( '%1$sNote:%2$s This setting has been disabled by the new WPGraphQL IDE. Related settings are now available under the "IDE Settings" tab.', 'wpgraphql-ide' ),
 				'<strong>',
 				'</strong>'
@@ -468,14 +471,14 @@ add_filter( 'graphql_setting_field_config', __NAMESPACE__ . '\\update_graphiql_l
 /**
  * Ensure the `show_graphiql_link_in_admin_bar` setting is always unchecked.
  *
- * @param mixed  $value          The value of the field.
- * @param mixed  $default_value  The default value if there is no value set.
- * @param string $option_name    The name of the option.
- * @param array  $section_fields The setting values within the section.
- * @param string $section_name   The name of the section the setting belongs to.
+ * @param mixed                $value          The value of the field.
+ * @param mixed                $default_value  The default value if there is no value set.
+ * @param string               $option_name    The name of the option.
+ * @param array<string, mixed> $section_fields The setting values within the section.
+ * @param string               $section_name   The name of the section the setting belongs to.
  * @return mixed The modified value of the field.
  */
-function ensure_graphiql_link_is_unchecked( $value, $default_value, $option_name, $section_fields, $section_name ) {
+function ensure_graphiql_link_is_unchecked( $value, $default_value, string $option_name, array $section_fields, string $section_name ) {
 	if ( 'show_graphiql_link_in_admin_bar' === $option_name && 'graphql_general_settings' === $section_name ) {
 		return 'off';
 	}


### PR DESCRIPTION
These changes resolve #150

## Screenshots

![IDE Settings](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/3b1d1d7d-c1ed-4634-b282-7c80738f97bf)

![legacy editor toggled off](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/e258b726-8400-4c9c-9d69-e42468b76726)

![legacy editor toggled on](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/59236b4c-0019-40a8-ae9b-a1228997f30c)

![settings](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/d719d531-b2a3-4623-be1f-9305ce4e7c63)
