### PR TITLE
feat: Add link to settings page

### DIFF
--- a/.changeset/silver-comics-arrive.md
+++ b/.changeset/silver-comics-arrive.md
@@ -1,0 +1,5 @@
+---
+"wpgraphql-ide": patch
+---
+
+- Add settings link to the IDE Settings tab from the WordPress settings page.

--- a/tests/e2e/specs/plugin-settings-link.spec.js
+++ b/tests/e2e/specs/plugin-settings-link.spec.js
@@ -1,0 +1,28 @@
+import { loginToWordPressAdmin, visitPluginsPage, wpAdminUrl } from '../utils.js';
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+export const selectors = {
+    pluginsMenuItem: '#menu-plugins a',
+    pluginSettingsLink: 'a[href*="graphql-settings#graphql_ide_settings"]',
+    ideSettingsTab: '#graphql_ide_settings-tab',
+};
+
+// Login to WordPress before each test
+test.beforeEach( async ( { page } ) => {
+    await loginToWordPressAdmin( page );
+} );
+
+test( 'should navigate to plugin settings and display IDE Settings tab', async ( { page } ) => {
+    // Go to Plugins page
+    await visitPluginsPage( page );
+
+    // Click on the plugin settings link
+    await page.click( selectors.pluginSettingsLink );
+
+    // Correct the expected URL string
+    const expectedUrl = `${wpAdminUrl}/admin.php?page=graphql-settings#graphql_ide_settings`;
+    await expect( page ).toHaveURL( expectedUrl );
+
+    // Check that the IDE Settings tab is visible
+    await expect( page.locator( selectors.ideSettingsTab ) ).toBeVisible();
+} );

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -591,17 +591,17 @@ function sanitize_custom_graphql_ide_link_behavior( $value ) {
 /**
  * Add settings link to the plugin actions
  *
- * @param array $links The existing action links.
- * @return array The modified action links.
+ * @param array<string> $links The existing action links.
+ * @return array<string> The modified action links.
  */
-function add_settings_link( $links ) {
-    $settings_link = sprintf(
-        '<a href="%s">%s</a>',
-        esc_url( admin_url( 'admin.php?page=graphql-settings#graphql_ide_settings' ) ),
-        esc_html__( 'Settings', 'wpgraphql-ide' )
-    );
-    array_unshift( $links, $settings_link );
-    return $links;
+function add_settings_link( array $links ): array {
+	$settings_link = sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( admin_url( 'admin.php?page=graphql-settings#graphql_ide_settings' ) ),
+		esc_html__( 'Settings', 'wpgraphql-ide' )
+	);
+	array_unshift( $links, $settings_link );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), __NAMESPACE__ . '\\add_settings_link' );
 

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -589,6 +589,23 @@ function sanitize_custom_graphql_ide_link_behavior( $value ) {
 }
 
 /**
+ * Add settings link to the plugin actions
+ *
+ * @param array $links The existing action links.
+ * @return array The modified action links.
+ */
+function add_settings_link( $links ) {
+    $settings_link = sprintf(
+        '<a href="%s">%s</a>',
+        esc_url( admin_url( 'admin.php?page=graphql-settings#graphql_ide_settings' ) ),
+        esc_html__( 'Settings', 'wpgraphql-ide' )
+    );
+    array_unshift( $links, $settings_link );
+    return $links;
+}
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), __NAMESPACE__ . '\\add_settings_link' );
+
+/**
  * Rename and reorder the submenu items under 'GraphQL'.
  */
 add_action(


### PR DESCRIPTION
These changes add a link to the IDE settings page from the plugins screen.

![ide-plugins-page](https://github.com/wp-graphql/wpgraphql-ide/assets/6676674/63d22ed9-5626-46a0-8b32-01cbf769a655)
