### PR TITLE
fix: reorder dependencies

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ ".", "https://downloads.wordpress.org/plugin/wp-graphql.zip" ],
+	"plugins": [ "https://downloads.wordpress.org/plugin/wp-graphql.zip", "." ],
 	"themes": [],
 	"port": 8888,
 	"config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wpgraphql-ide",
-  "version": "2.1.2",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wpgraphql-ide",
-      "version": "2.1.2",
+      "version": "2.1.4",
       "dependencies": {
         "@changesets/cli": "^2.27.1",
         "@graphiql/react": "^0.22.2",


### PR DESCRIPTION
The following changes reorder the plugins array in .wp-env.json in order to fix the "Required By" bug as seen here https://github.com/wp-graphql/wpgraphql-ide/actions/runs/9819008753/job/27469203288?pr=179#step:6:175