### PR TITLE
fix: custom user role assignment

### DIFF
--- a/.changeset/little-melons-design.md
+++ b/.changeset/little-melons-design.md
@@ -1,0 +1,5 @@
+---
+"wpgraphql-ide": patch
+---
+
+Fixes issue where custom capability was not being assigned to the administrator role. This now happens on plugin activation.

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -91,7 +91,7 @@ function show_admin_notice() {
 /**
  * Assign custom capability to administrator role on plugin activation.
  */
-function wpgraphql_ide_activate() {
+function wpgraphql_ide_activate(): void {
 	$administrator = get_role( 'administrator' );
 	if ( $administrator ) {
 		$administrator->add_cap( 'manage_graphql_ide' );

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -89,6 +89,32 @@ function show_admin_notice() {
 }
 
 /**
+ * Assign custom capability to administrator role on plugin activation.
+ */
+function wpgraphql_ide_activate() {
+    $administrator = get_role( 'administrator' );
+    if ( $administrator ) {
+        $administrator->add_cap( 'manage_graphql_ide' );
+    }
+}
+register_activation_hook( __FILE__, __NAMESPACE__ . '\\wpgraphql_ide_activate' );
+
+/**
+ * Adds custom capabilities to specified roles.
+ */
+function add_custom_capabilities(): void {
+    $capabilities = get_custom_capabilities();
+    $current_hash = generate_capabilities_hash( $capabilities );
+
+    if ( ! has_capabilities_hash_changed( $current_hash ) ) {
+        return;
+    }
+
+    update_roles_capabilities( $capabilities );
+    save_capabilities_hash( $current_hash );
+}
+
+/**
  * Retrieves the custom capabilities and their associated roles for the plugin.
  *
  * @return array<string,mixed> The array of custom capabilities and roles.
@@ -144,21 +170,6 @@ function update_roles_capabilities( $capabilities ): void {
  */
 function save_capabilities_hash( $current_hash ): void {
 	update_option( 'wpgraphql_ide_capabilities', $current_hash );
-}
-
-/**
- * Adds custom capabilities to specified roles.
- */
-function add_custom_capabilities(): void {
-	$capabilities = get_custom_capabilities();
-	$current_hash = generate_capabilities_hash( $capabilities );
-
-	if ( ! has_capabilities_hash_changed( $current_hash ) ) {
-		return;
-	}
-
-	update_roles_capabilities( $capabilities );
-	save_capabilities_hash( $current_hash );
 }
 
 /**

--- a/wpgraphql-ide.php
+++ b/wpgraphql-ide.php
@@ -92,10 +92,10 @@ function show_admin_notice() {
  * Assign custom capability to administrator role on plugin activation.
  */
 function wpgraphql_ide_activate() {
-    $administrator = get_role( 'administrator' );
-    if ( $administrator ) {
-        $administrator->add_cap( 'manage_graphql_ide' );
-    }
+	$administrator = get_role( 'administrator' );
+	if ( $administrator ) {
+		$administrator->add_cap( 'manage_graphql_ide' );
+	}
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\wpgraphql_ide_activate' );
 
@@ -103,15 +103,15 @@ register_activation_hook( __FILE__, __NAMESPACE__ . '\\wpgraphql_ide_activate' )
  * Adds custom capabilities to specified roles.
  */
 function add_custom_capabilities(): void {
-    $capabilities = get_custom_capabilities();
-    $current_hash = generate_capabilities_hash( $capabilities );
+	$capabilities = get_custom_capabilities();
+	$current_hash = generate_capabilities_hash( $capabilities );
 
-    if ( ! has_capabilities_hash_changed( $current_hash ) ) {
-        return;
-    }
+	if ( ! has_capabilities_hash_changed( $current_hash ) ) {
+		return;
+	}
 
-    update_roles_capabilities( $capabilities );
-    save_capabilities_hash( $current_hash );
+	update_roles_capabilities( $capabilities );
+	save_capabilities_hash( $current_hash );
 }
 
 /**


### PR DESCRIPTION
This change assigns the custom capability, `manage_graphql_ide`, to the administrator role on plugin activation.