### PR TITLE
fix: Ensure CodeMirror-lint-tooltip is visible when IDE is in drawer

### DIFF
--- a/.changeset/pretty-turtles-buy.md
+++ b/.changeset/pretty-turtles-buy.md
@@ -1,0 +1,5 @@
+---
+"wpgraphql-ide": patch
+---
+
+fix: linting tooltips are now visible when using the IDE in the drawer

--- a/styles/wpgraphql-ide.css
+++ b/styles/wpgraphql-ide.css
@@ -116,6 +116,11 @@ body:not(.graphql_page_graphql-ide) {
   z-index: 100002 !important; /* #wpadminar's z-index of 99999 + 3 */
 }
 
+/* Fix GraphiQL tooltips and hover popovers within drawer */
+.CodeMirror-lint-tooltip{
+  z-index: 100002 !important; /* #wpadminar's z-index of 99999 + 3 */
+}
+
 .graphiql-dialog-title,
 .graphiql-history-header {
   color: hsla(var(--color-neutral),1);


### PR DESCRIPTION
This resolves #225.